### PR TITLE
empty structs use don't take any space

### DIFF
--- a/stegify.go
+++ b/stegify.go
@@ -94,13 +94,14 @@ func parseOperation() string {
 	}
 	operation := os.Args[1]
 	if operation != encode && operation != decode {
-		helpFlags := map[string]bool{
-			"--help": true,
-			"-help":  true,
-			"--h":    true,
-			"-h":     true,
+		helpFlags := map[string]struct{}{
+			"--help": struct{}{},
+			"-help":  struct{}{},
+			"--h":    struct{}{},
+			"-h":     struct{}{},
 		}
-		if helpFlags[operation] {
+
+		if _, ok := helpFlags[operation]; ok {
 			flag.Parse()
 			os.Exit(0)
 		}


### PR DESCRIPTION
Hi, I'm a beginner to Go and  I started using this project to get comfortable with the language. 
This is a pretty small change but empty structs don't take any space compared to using booleans which use a bit.
https://dave.cheney.net/2014/03/25/the-empty-struct 